### PR TITLE
HF: Support DC module and PI3020 VR sensors

### DIFF
--- a/meta-facebook/meta-hammerface/recipes-hammerface/plat-libs/files/pal/pal.h
+++ b/meta-facebook/meta-hammerface/recipes-hammerface/plat-libs/files/pal/pal.h
@@ -149,6 +149,25 @@ enum {
   FRU_RISER_SLOT4 = 5,
 };
 
+enum {
+  DC_IN_VOLT = 0x88,
+  DC_OUT_VOLT = 0x8B,
+  DC_OUT_CURR = 0x8C,
+  DC_TEMP = 0x8D,
+  DC_OUT_POWER = 0x96,
+};
+
+enum {
+  HSC_IN_VOLT = 0x88,
+  HSC_IN_CURR = 0x89,
+  HSC_OUT_VOLT = 0x8B,
+  HSC_OUT_CURR = 0x8C,
+  HSC_OUT_POWER = 0x96,
+  HSC_IN_POWER = 0x97,
+  HSC_TEMP = 0x8D,
+};
+
+
 // Sensors Under Side Plane
 enum {
   MB_SENSOR_HSC_IN_POWER = 0x29,
@@ -158,6 +177,13 @@ enum {
 
   MB_SENSOR_CPU0_TJMAX = 0x30,
   MB_SENSOR_CPU1_TJMAX = 0x31,
+
+  /*Tony test*/
+  DC_SENSOR_IN_VOLT = 0x33,
+  DC_SENSOR_OUT_VOLT = 0x34,
+  DC_SENSOR_OUT_CURR = 0x35,
+  DC_SENSOR_OUT_POWER = 0x36,
+  DC_SENSOR_TEMP = 0x37,
 
   MB_SENSOR_PCH_TEMP = 0x08,
   MB_SENSOR_CPU0_THERM_MARGIN = 0x09,

--- a/meta-facebook/meta-hammerface/recipes-hammerface/plat-libs/files/vr/vr.h
+++ b/meta-facebook/meta-hammerface/recipes-hammerface/plat-libs/files/vr/vr.h
@@ -45,6 +45,47 @@ enum {
 };
 
 enum {
+  CMD_READ = 0xDC,
+  CMD_WRITE = 0xDA,
+  CMD_SAVE = 0xDB,
+};
+
+enum
+{
+  //temperature
+  TEMP_LOW_MULT1 = 0x10,
+  TEMP_HIGH_MULT1 = 0x11,
+  TEMP_LOW_OFFSET1 = 0x12,
+  TEMP_HIGH_OFFSET1 = 0x13,
+  TEMP_LOW_MULT2 = 0x14,
+  TEMP_HIGH_MULT2 = 0x15,
+  TEMP_REG = 0x16,
+  TEMP_ZONE = 0x17,
+
+  //Current
+  OUT_CURRENT_LOW_MULT1 = 0x34,
+  OUT_CURRENT_HIGH_MULT1 = 0x35,
+  OUT_CURRENT_LOW_OFFSET1 = 0x36,
+  OUT_CURRENT_HIGH_OFFSET1 = 0x37,
+  OUT_CURRENT_LOW_MULT2 = 0x38,
+  OUT_CURRENT_HIGH_MULT2 = 0x39,
+  OUT_CURRENT_REG = 0x3A,
+  OUT_CURRENT_SVID = 0x3C,
+
+  //Power
+  IN_PWR_LOW_MULT1 = 0x20,
+  IN_PWR_HIGH_MULT1 = 0x21,
+  IN_PWR_LOW_OFFSET1 = 0x22,
+  IN_PWR_HIGH_OFFSET1 = 0x23,
+  IN_PWR_LOW_MULT2 = 0x24,
+  IN_PWR_HIGH_MULT2 = 0x25,
+  IN_PWR_REG = 0x27,
+  IN_PWR_SVID = 0x28,
+  IN_VOL_RAW = 0x2B,
+  IN_CURRENT_RAW = 0x2C,
+};
+
+enum {
   VR_LOOP_PAGE_0 = 0x60,
   VR_LOOP_PAGE_1 = 0x61,
   VR_LOOP_PAGE_2 = 0x62
@@ -55,6 +96,11 @@ enum {
   VR_STATUS_FAILURE       = -1,
   VR_STATUS_NOT_AVAILABLE = -2,
 };
+
+int vr_read_PI3020_volt(uint8_t vr, float *value);
+int vr_read_PI3020_current(uint8_t vr, float *value);
+int vr_read_PI3020_power(uint8_t vr, float *value);
+int vr_read_PI3020_temp(uint8_t vr, float *value);
 
 int vr_fw_version(uint8_t vr, char *outvers_str);
 int vr_fw_update(uint8_t fru, uint8_t board_info, const char *file);


### PR DESCRIPTION
Summary
-BMC can show the DC module and PI3020 VR sensors

Test Plan
-Build code(Pass)
-use sensor-util to check the reading of the DC module(Pass)
-use sensor-util to check the reading of the PI3020(Pass)

1. DC module sensors
MB_DC_IN_VOLT                (0x33) :   48.38 Volts | (ok)
MB_DC_OUT_VOLT               (0x34) :   12.21 Volts | (ok)
MB_DC_OUT_CURRENT            (0x35) :    0.00 Amps  | (ok)
MB_DC_OUT_POWER              (0x36) :    0.00 Watts | (ok)
MB_DC_OUT_TEMP               (0x37) :   85.00 C     | (ok)

2. CPU VCCIN sensors
root@bmc:~# sensor-util all | grep -i vccin
MB_VR_CPU0_VCCIN_TEMP        (0xB1) :   48.00 C     | (ok)
MB_VR_CPU0_VCCIN_CURR        (0xB2) :    0.00 Amps  | (ok)
MB_VR_CPU0_VCCIN_VOLT        (0xB0) :   48.24 Volts | (ucr)
MB_VR_CPU0_VCCIN_POWER       (0xB3) :    0.00 Watts | (ok)
MB_VR_CPU1_VCCIN_TEMP        (0xF1) :   53.00 C     | (ok)
MB_VR_CPU1_VCCIN_CURR        (0xF2) :    0.11 Amps  | (ok)
MB_VR_CPU1_VCCIN_VOLT        (0xF0) :   48.24 Volts | (ucr)
MB_VR_CPU1_VCCIN_POWER       (0xF3) :    2.00 Watts | (ok)